### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check_quality.yml
+++ b/.github/workflows/check_quality.yml
@@ -14,6 +14,9 @@ on:
   schedule:
     - cron: '0 0 * * 0'  # Runs at 00:00 every Sunday
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sbush92/Portfolio/security/code-scanning/1](https://github.com/sbush92/Portfolio/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/check_quality.yml` so all jobs inherit minimal token access unless overridden.  
For this workflow, the best non-functional-change fix is:

- Add under the workflow triggers (before `jobs:`):
  - `permissions:`
  - `  contents: read`

This grants only read access to repository contents, which is sufficient for `actions/checkout` and running lint/tests. No imports, methods, or additional definitions are needed since this is YAML config only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
